### PR TITLE
Migrate away from the deprecated list function

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,15 +249,15 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
@@ -267,26 +267,26 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| convert\_case | Convert fields to lower case | `bool` | `true` | no |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
-| name | Solution name, e.g. `app` or `jenkins` | `string` | `""` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev' | `string` | `""` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_convert_case"></a> [convert\_case](#input\_convert\_case) | Convert fields to lower case | `bool` | `true` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. `app` or `jenkins` | `string` | `""` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev' | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| attributes | Normalized attributes |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` |
-| id | Disambiguated ID |
-| name | Normalized name |
-| namespace | Normalized namespace |
-| stage | Normalized stage |
-| tags | Normalized Tag map |
+| <a name="output_attributes"></a> [attributes](#output\_attributes) | Normalized attributes |
+| <a name="output_delimiter"></a> [delimiter](#output\_delimiter) | Delimiter between `namespace`, `stage`, `name` and `attributes` |
+| <a name="output_id"></a> [id](#output\_id) | Disambiguated ID |
+| <a name="output_name"></a> [name](#output\_name) | Normalized name |
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | Normalized namespace |
+| <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
+| <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,15 +3,15 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 
 ## Providers
 
-No provider.
+No providers.
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
@@ -21,24 +21,24 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| convert\_case | Convert fields to lower case | `bool` | `true` | no |
-| delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
-| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
-| name | Solution name, e.g. `app` or `jenkins` | `string` | `""` | no |
-| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
-| stage | Stage, e.g. 'prod', 'staging', 'dev' | `string` | `""` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| <a name="input_convert_case"></a> [convert\_case](#input\_convert\_case) | Convert fields to lower case | `bool` | `true` | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. `app` or `jenkins` | `string` | `""` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev' | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| attributes | Normalized attributes |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` |
-| id | Disambiguated ID |
-| name | Normalized name |
-| namespace | Normalized namespace |
-| stage | Normalized stage |
-| tags | Normalized Tag map |
+| <a name="output_attributes"></a> [attributes](#output\_attributes) | Normalized attributes |
+| <a name="output_delimiter"></a> [delimiter](#output\_delimiter) | Delimiter between `namespace`, `stage`, `name` and `attributes` |
+| <a name="output_id"></a> [id](#output\_id) | Disambiguated ID |
+| <a name="output_name"></a> [name](#output\_name) | Normalized name |
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | Normalized namespace |
+| <a name="output_stage"></a> [stage](#output\_stage) | Normalized stage |
+| <a name="output_tags"></a> [tags](#output\_tags) | Normalized Tag map |
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  original_tags    = join(var.delimiter, compact(concat(list(var.namespace, var.stage, var.name), var.attributes)))
+  original_tags    = join(var.delimiter, compact(concat(tolist([var.namespace, var.stage, var.name]), var.attributes)))
   transformed_tags = var.convert_case ? lower(local.original_tags) : local.original_tags
 }
 


### PR DESCRIPTION
Now that Terraform 0.15 is [released](https://www.hashicorp.com/blog/announcing-hashicorp-terraform-0-15-general-availability), I've run into some issues with this module as it is using a function that got removed, namely [`list`](https://www.terraform.io/docs/language/functions/list.html). This PR replaces it with [`tolist`](https://www.terraform.io/docs/language/functions/tolist.html).

Error from Terraform 0.15 for reference:
```
│ Error: Error in function call
│ 
│   on .terraform/modules/default_label/main.tf line 2, in locals:
│    2:   original_tags    = join(var.delimiter, compact(concat(list(var.namespace, var.stage, var.name), var.attributes)))
│     ├────────────────
│     │ var.name is a string, known only after apply
│     │ var.namespace is a string, known only after apply
│     │ var.stage is a string, known only after apply
│ 
│ Call to function "list" failed: the "list" function was deprecated in
│ Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to
│ write a literal list.
```